### PR TITLE
(Feature) Read from Directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "concat-reader"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +155,7 @@ dependencies = [
 name = "fastlyzer"
 version = "0.1.0"
 dependencies = [
+ "concat-reader 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -448,6 +454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum concat-reader 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "230065ffb4349e6bdb6cffc8f60f22f1e92db7786efb1fa63564ddb47af7efcb"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ version = "0.1.0"
 dependencies = [
  "concat-reader 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator-global 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,11 +165,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator-global"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -462,7 +496,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+"checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+"checksum jemallocator-global 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "991b61de8365c8b5707cf6cabbff98cfd6eaca9b851948b883efea408c7f581e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ structopt = "0.3.0"
 tabwriter = "1.1.0"
 regex = "1.3.1"
 jemallocator-global = "0.3.0"
+concat-reader = "0.1.0"
 
 [lib]
 name = "fastlyzer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ failure = "0.1.5"
 structopt = "0.3.0"
 tabwriter = "1.1.0"
 regex = "1.3.1"
+concat-reader = "0.1.0"
 
 [lib]
 name = "fastlyzer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ failure = "0.1.5"
 structopt = "0.3.0"
 tabwriter = "1.1.0"
 regex = "1.3.1"
+jemallocator-global = "0.3.0"
 concat-reader = "0.1.0"
 
 [lib]

--- a/src/bin/fastlyzer.rs
+++ b/src/bin/fastlyzer.rs
@@ -1,5 +1,5 @@
 #![deny(rust_2018_idioms)]
-use fastlyzer::{run, read, FastResult};
+use fastlyzer::{run, reader, FastResult};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -21,7 +21,7 @@ struct Opt {
 
 fn main() -> FastResult<()> {
     let opt = Opt::from_args();
-    let file = read(&opt.input)?;
+    let file = reader(&opt.input)?;
     let filters = opt
         .filter
         .as_ref()

--- a/src/bin/fastlyzer.rs
+++ b/src/bin/fastlyzer.rs
@@ -1,5 +1,5 @@
 #![deny(rust_2018_idioms)]
-use fastlyzer::{get_domains, read, FastResult};
+use fastlyzer::{run, read, FastResult};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -35,6 +35,6 @@ fn main() -> FastResult<()> {
                 .collect()
         })
         .unwrap_or_else(Vec::new);
-    get_domains(file, opt.max, &opt.selector, filters);
+    run(file, opt.max, &opt.selector, filters);
     Ok(())
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ use std::{
 use rayon::prelude::*;
 use tabwriter::TabWriter;
 
-pub fn get_domains(
+pub fn run(
     reader: Box<dyn BufRead>,
     max: usize,
     selector: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![deny(rust_2018_idioms)]
 
-pub use commands::get_domains;
+pub use commands::run;
 pub use errors::FastResult;
-pub use rw::read;
+pub use rw::reader;
 
 pub mod commands;
 pub mod errors;

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -7,19 +7,20 @@ use std::{
 use concat_reader::concat_path;
 
 pub fn reader(file: &str) -> FastResult<Box<dyn BufRead>> {
-    let mut res = vec![];
     let path = Path::new(file);
     if path.is_dir() {
-        for file in path.read_dir() {
-            let mut paths = file
-                .into_iter()
-                .map(|f| f.unwrap().path())
-                .collect();
-
-            let mut f = concat_path(paths);
-            let mut con = BufReader::new(f);
-            Ok(Box::new(con))
-        }
+        let paths = path.read_dir()
+            .into_iter()
+            .map(|file| {
+                file.into_iter()
+                    .map(|f| f.unwrap().path())
+                    .collect::<Vec<_>>()
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+        let mut f = concat_path(paths);
+        let mut con = BufReader::new(f);
+        Ok(Box::new(con))
     } else {
         let file = OpenOptions::new().read(true).open(&path)?;
         let buff = BufReader::new(file);

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -4,15 +4,25 @@ use std::{
     io::{BufRead, BufReader},
     path::Path,
 };
+use concat_reader::concat_path;
 
-pub fn read(file: &str) -> FastResult<Box<dyn BufRead>> {
+pub fn reader(file: &str) -> FastResult<Box<dyn BufRead>> {
+    let mut res = vec![];
     let path = Path::new(file);
-    let file = OpenOptions::new().read(true).open(&path)?;
-    Ok(Box::new(BufReader::new(file)))
-}
+    if path.is_dir() {
+        for file in path.read_dir() {
+            let mut paths = file
+                .into_iter()
+                .map(|f| f.unwrap().path())
+                .collect();
 
-//pub fn write(strings: &str) {
-//    let mut tw = TabWriter::new(io::stdout());
-//    write!(&mut tw, "{}", strings).unwrap();
-//    tw.flush().unwrap();
-//}
+            let mut f = concat_path(paths);
+            let mut con = BufReader::new(f);
+            Ok(Box::new(con))
+        }
+    } else {
+        let file = OpenOptions::new().read(true).open(&path)?;
+        let buff = BufReader::new(file);
+        Ok(Box::new(buff))
+    }
+}

--- a/src/rw.rs
+++ b/src/rw.rs
@@ -12,15 +12,14 @@ pub fn reader(file: &str) -> FastResult<Box<dyn BufRead>> {
         let paths = path.read_dir()
             .into_iter()
             .map(|file| {
-                file.into_iter()
-                    .map(|f| f.unwrap().path())
+                file.map(|f| f.unwrap().path())
                     .collect::<Vec<_>>()
             })
             .flatten()
             .collect::<Vec<_>>();
-        let mut f = concat_path(paths);
-        let mut con = BufReader::new(f);
-        Ok(Box::new(con))
+        let file = concat_path(paths);
+        let buff = BufReader::new(file);
+        Ok(Box::new(buff))
     } else {
         let file = OpenOptions::new().read(true).open(&path)?;
         let buff = BufReader::new(file);


### PR DESCRIPTION
# Context

This will add the ability to read every file in a directory and combine the results before writing the results to std-out.

# Technical

Currently it determines if the path provided to `-i` is a directory or a file, in the case of directory it will combine all the read buffers into one and pass it to the `run()` function.

# Issues

- Reading from a directory that contains sub-directories throws an unwrap error
- Reading from a directory that contains files larger than available RAM crashes/freezes the OS