### PR TITLE
Filter directory entries from list of files to read

### DIFF
--- a/src/rw.rs
+++ b/src/rw.rs
@@ -1,21 +1,20 @@
 use crate::FastResult;
+use concat_reader::concat_path;
 use std::{
     fs::OpenOptions,
     io::{BufRead, BufReader},
     path::Path,
 };
-use concat_reader::concat_path;
 
 pub fn reader(file: &str) -> FastResult<Box<dyn BufRead>> {
     let path = Path::new(file);
     if path.is_dir() {
-        let paths = path.read_dir()
+        let paths = path
+            .read_dir()
             .into_iter()
-            .map(|file| {
-                file.map(|f| f.unwrap().path())
-                    .collect::<Vec<_>>()
-            })
+            .map(|file| file.map(|f| f.unwrap().path()).collect::<Vec<_>>())
             .flatten()
+            .filter(|path| path.is_file())
             .collect::<Vec<_>>();
         let file = concat_path(paths);
         let buff = BufReader::new(file);


### PR DESCRIPTION
Fixes #3.

The problem with the current approach to directory iteration was that the resulting reader contained files as well as directories. When the reader tried to open the directory, the operation failed.

The fix for now is to simply skip directories before opening the log files in the reader.

Another approach would be to recurse into subdirectories. Which approach do you prefer?