### PR TITLE
Use Snapcraft

### DIFF
--- a/.github/workflows/snapcraft_edge.yml
+++ b/.github/workflows/snapcraft_edge.yml
@@ -1,0 +1,24 @@
+name: Snapcraft Publish
+
+on:
+  release:
+    types: [prereleased]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v1
+        with:
+          snapcraft_token: ${{ secrets.snapcraft_token }}
+
+      - name: Build snap
+        run: snapcraft
+
+      - name: Push snap
+        run: snapcraft push fastlyzer_*_amd64.snap --release edge

--- a/.github/workflows/snapcraft_stable.yml
+++ b/.github/workflows/snapcraft_stable.yml
@@ -1,0 +1,24 @@
+name: Snapcraft Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v1
+        with:
+          snapcraft_token: ${{ secrets.snapcraft_token }}
+
+      - name: Build snap
+        run: snapcraft
+
+      - name: Push snap
+        run: snapcraft push fastlyzer_*_amd64.snap --release stable

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+# Rust
 /target
 **/*.rs.bk
 .idea/*
+
+# Snapcraft
+/parts/
+/stage/
+/prime/
+/*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: fastlyzer
+base: core18
+version: '0.2.0'
+summary: A log reader and analyzer
+description: |
+  Originally designed to analyze Fastly logs but can be used for any log file containing one JSON entry per line.
+
+grade: devel
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  fastlyzer:
+    plugin: rust
+    source: .
+    build-packages:
+      - make
+      - libjemalloc-dev
+
+apps:
+  fastlyzer:
+    command: bin/fastlyzer


### PR DESCRIPTION
# Context
Currently, Fastlyzer users have to clone the repo and perform a cargo install in order to use this tool.

It might be beneficial to add a basic [Snapcraft](https://snapcraft.io) definition so we can start publishing for `snap`.

# Technical
There are three things to note here:
- The Snapcraft definition
- The "release" Github action
- The "prerelease" Github action

The two github actions are triggered by the same general action-- publishing a release on Github. However, if you explicitly mark a release as "prerelease," it'll run the prerelease action which publishes to the `edge` channel on `snap`.

In order for this to work properly, we'll have to add the `snapcraft_token` secret in this repo's settings.